### PR TITLE
Develop the cybersecurity learning app

### DIFF
--- a/src/components/PomodoroTimer.vue
+++ b/src/components/PomodoroTimer.vue
@@ -28,7 +28,7 @@ const currentMode = ref<typeof modes[number]>('work');
 const timeLeft = ref(durations[currentMode.value]);
 const running = ref(false);
 const completedSessions = ref(0);
-let timer: number | null = null;
+let timer: ReturnType<typeof setInterval> | null = null;
 
 const minutes = computed(() => String(Math.floor(timeLeft.value / 60)).padStart(2, '0'));
 const seconds = computed(() => String(timeLeft.value % 60).padStart(2, '0'));


### PR DESCRIPTION
Update PomodoroTimer's timer type to fix TypeScript build error.

The `setInterval` function returns a `Timeout` object in Node.js environments (like Vercel's build server), which caused a TypeScript error when assigned to a `number` type. This change uses `ReturnType<typeof setInterval>` for correct type compatibility.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-079afdbc-dbf5-4fcb-9d7a-454ed33ededa) · [Cursor](https://cursor.com/background-agent?bcId=bc-079afdbc-dbf5-4fcb-9d7a-454ed33ededa)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)